### PR TITLE
Retrieve github user email

### DIFF
--- a/src/multi_auth/providers/github.cr
+++ b/src/multi_auth/providers/github.cr
@@ -58,6 +58,8 @@ class MultiAuth::Provider::Github < MultiAuth::Provider
     gh_user = GhUser.from_json(raw_json)
     gh_user.access_token = access_token
     gh_user.raw_json = raw_json
+    raw_email_json = api.get("/user/emails").body
+    gh_user.email = JSON.parse(raw_email_json)[0]["email"].to_s
     gh_user
   end
 


### PR DESCRIPTION
One additional api call is required to retrieve the github user's email.
The returned json i format is 
```json
[ {"email":"email ... address", ...}]
```
For simplicity it was done as a one-liner.